### PR TITLE
PortScannerDetector

### DIFF
--- a/PortScannerDetector.py
+++ b/PortScannerDetector.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # ****************************************************************************************************
 # Name: Ryan Vacca
 #       Matthew Moltzaou
@@ -27,7 +29,7 @@ SUB_NET = "192.168.10."   # Subnet of LAN
 OLD_ENTRY_TIME = 5        # Time value in minutes for stale table entry
 FAN_OUT_SEC = 5           # Fan out rate for per second
 FAN_OUT_MIN = 100         # Fan out rate for per minute
-FAN_OUT_FIVE_MIN = 300     # Fan out rate for per five minute
+FAN_OUT_FIVE_MIN = 300    # Fan out rate for per five minute
 HASH_TABLE_SIZE = 262144  # Size of hash table: (256 "IP's") * (1024 "Ports") = 262144 Total possible entries
 
 STALE_ENTRY = False
@@ -48,10 +50,6 @@ IPADDRESS_SOURCE = 1
 IPADDRESS_DESTINATION = 2
 PORT_DESTINATION = 3
 TIME_STAMP = 4
-
-
-
-
 
 # Make Hash table of connections global
 # Each entry in the hash table is comprised of a tuple in regards to an attempted connection
@@ -74,11 +72,11 @@ hashTable = {}
 def populateHashTable():
     IPkeys = 0      # Index for IPAddress's
     PortKeys = 0    # Index for Port's
-   
+    
     # Loop Through Table adding entries
     for i in range(HASH_TABLE_SIZE): # Range = 262144
         hashTable[i] = (STALE_ENTRY, mapkeyToIp(str(IPkeys)), EMPTY_STRING, PortKeys, ZERO_TIME)
-
+        
         if(PortKeys == PORT_MAX):
             PortKeys = 0
             IPkeys += 1
@@ -130,8 +128,6 @@ def initiateThreads():
     print("Program exit.")
 
 
-
-
 # ----------------------------- Thread 1 : Sniff Traffic Functions ----------------------------------#
 
 # ****************************************************************************************************
@@ -142,29 +138,29 @@ def initiateThreads():
 # Note: TODO: Needs work !! Correctly sniffs traffic but doesnt yet populate the table 
 # ****************************************************************************************************
 def snifferThread(num): 
-
+    
     print("Inside Sniffer: {}".format(num))
-
+    
     # Create a Raw Socket
     packets = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(0x0800))
-
+    
     # Main loop to listen for packets on LAN
     while True:
-
+        
         # Max buffer size that can be defined
         # Return 1) ethernet data which is what is in the packet to which we will do
         # analysis on, We do not us address for this lab, implement dummy catcher
         ethernet_data, address = packets.recvfrom(65536)
-
+        
         # Call function to parse returned frame
         dest_mac, src_mac, protocol, ip_data = ethernet_dissect(ethernet_data)
-
+        
         # Exterior Gateway Protocol IP4 packet, which we are using.
         if protocol == 8:
-
+            
             # Call function to parse IPV4 packet
             ip_protocol, source_ip, dest_ip, transport_data = ipv4_dissect(ip_data)
-
+            
             # TCP Protocol within IP4 Packet
             if ip_protocol == 6:
                 # TCP Parse Source and Destination Port portion of packet
@@ -175,9 +171,7 @@ def snifferThread(num):
                 # ***** TODO ******
                 # TEST THIS , function below logic works but havent run with live scan
                 updateTableEntry(source_ip, dest_ip, dest_port)
-
-
-
+            
             # UDP Protocol within IP4 Packet
             if ip_protocol == 17:
                 # UDP Parse Source and Destination Port portion of packet
@@ -297,8 +291,6 @@ def updateTableEntry(ip_src, ip_dest, port_dest):
     hashTable[table_index] = tuple(temp)
 
 
-
-
 # ----------------------------- Thread 2 : Fan Out Rate Functions -----------------------------------#
 
 # ****************************************************************************************************
@@ -332,13 +324,14 @@ def fannerOutput(second, minute, fiveminute, IPAddress):
 #****************************************************************************************************
 # LOGIC BEHIND CHECKING THE TABLE FOR ENTRIES THAT TRIGGER AN IP ADDRESS AS A SCANNER 
 # TODO: NEEDS WORK 
-def fannerSecond(ipAddress, currentTime, totalTime)
+def fannerSecond(ipAddress, currentTime, totalTime):
     avg_time = totalTime/PORT_MATH
-def fannerMinute(ipAddress, currentTime, totalTime)
-def fannerFiveMinute(ipAddress, currentTime, totalTime)
 
-def fannerCalculation()
-{
+#def fannerMinute(ipAddress, currentTime, totalTime)
+#def fannerFiveMinute(ipAddress, currentTime, totalTime)
+
+def fannerCalculation():
+    
     # Initial time prior to loop
     current_time = time.time()
     time_stamp = 0 
@@ -358,7 +351,7 @@ def fannerCalculation()
                 current_time = time.time()
         
         time_stamp += hashTable[i][TIME_STAMP]
-}
+
 #****************************************************************************************************
 
 
@@ -404,9 +397,6 @@ def checkTimeOutTableEntry():
  
             # Update table
             hashTable[i] = tuple(temp)
-
-
-
 
 # ----------------------------------- Common Helper Functions ---------------------------------------#
 
@@ -456,8 +446,6 @@ def mapToIndex(ip_src, port_dest):
         return (PORT_MATH * index) + port_dest
 
 
-
-
 # ---------------------------------------- Main Function --------------------------------------------#
 
 # ****************************************************************************************************
@@ -467,22 +455,10 @@ def mapToIndex(ip_src, port_dest):
 # Returns: Nothing
 # **************************************************************************************************** 
 def main():
-
     populateHashTable()     
     printHashTable()
-    
 
 # Program entry 
 if __name__ == "__main__": 
     main()
-
-
-
-
-
-
-
-
-
-
 

--- a/detector/detector.py
+++ b/detector/detector.py
@@ -1,4 +1,3 @@
-import sys
 from datetime import datetime
 
 _caught_ips = {}
@@ -55,15 +54,15 @@ def get_counts(table, ip_connections):
 # waits a minute for already-reported ips to avoid spam
 def report_ip(ip, avg_per_sec, avg_per_min, total_count):
     
-    sys.stdout.flush()
-    if ip not in _caught_ips:
-        print("port scanner detected on source IP %s" % ip)
-    else:
+    if ip in _caught_ips:
         elapsed_min = int((_caught_ips[ip] - datetime.now()).total_seconds() / 60)
         if elapsed_min == 0:
             return
     
+    message = (
+        "port scanner detected on source IP %s\n"
+        "avg fan-out per second: %s, avg fan-out per min: %s, fan-out per 5 min: %s")
+    print(message % (ip, avg_per_sec, avg_per_min, total_count))
     _caught_ips[ip] = datetime.now()
-    print("avg fan-out per second: %s, avg fan-out per min: %s, fan-out per 5 min: %s" % 
-            (avg_per_sec, avg_per_min, total_count))
+
 

--- a/detector/detector.py
+++ b/detector/detector.py
@@ -1,0 +1,69 @@
+import sys
+from datetime import datetime
+
+_caught_ips = {}
+
+def detect(channel):
+
+    while True:
+         
+        table = channel.get()
+        
+        # ip -> (sec_count_list, min_count_list, total_count)
+        ip_connections = {}
+        get_counts(table, ip_connections)
+        
+        channel.put(table)
+        
+        avg = lambda lst: sum(lst) / len(lst)
+        
+        for ip, counts in ip_connections.items():
+            seconds, minutes, total_count = counts
+            avg_per_sec = avg(seconds)
+            avg_per_min = avg(minutes)
+            
+            if avg_per_sec > 5 or avg_per_min > 100 or total_count > 300:
+                report_ip(ip, avg_per_sec, avg_per_min, total_count)
+
+# for each ip in the table, what is the frequency of occurances per second, per minute, and total?
+# mutates the ip_connections dictionary to contain the new count information
+# only information from the last 5 minutes is considered, the table is updated if an entry should be deleted
+def get_counts(table, ip_connections):
+    
+    del_keys = []
+    for key, time in table.items():
+        
+        diff_seconds = int((datetime.now() - time).total_seconds())
+        diff_minutes = int(diff_seconds / 60)
+        ip = key[0]
+        
+        if diff_seconds >= 300:
+            del_keys.append(key)
+        else:
+            # seconds is an array of 300 for 1 second intervals across 5 minutes
+            # minutes is an array of 5 for 1 minute intervals across 5 minutes
+            seconds, minutes, total_count = ip_connections.get(ip, ([0] * 300, [0] * 5, 0))
+            seconds[diff_seconds] += 1
+            minutes[diff_minutes] += 1
+            ip_connections[ip] = (seconds, minutes, total_count + 1)
+
+    # items can't be deleted from a dictionary as you iterate over it
+    for key in del_keys:
+        del table[key]
+
+# prints the ip information to the screen
+# waits a minute for already-reported ips to avoid spam
+def report_ip(ip, avg_per_sec, avg_per_min, total_count):
+    
+    sys.stdout.flush()
+    if ip not in _caught_ips:
+        print("port scanner detected on source IP %s" % ip)
+    else:
+        elapsed_min = int((_caught_ips[ip] - datetime.now()).total_seconds() / 60)
+        if elapsed_min == 0:
+            return
+    
+    _caught_ips[ip] = datetime.now()
+    print("avg fan-out per second: %s, avg fan-out per min: %s, fan-out per 5 min: %s" % 
+            (avg_per_sec, avg_per_min, total_count))
+

--- a/detector/main.py
+++ b/detector/main.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+from threading import Thread
+from queue import Queue
+from time import sleep
+
+from sniffer import sniff
+from sniffer import dissect
+from detector import detect
+
+def main():
+    
+    # Using queues for synchronization and data control
+    data_queue = Queue()
+    channel = Queue()
+    table = {}
+    channel.put(table)
+    
+    print("Port scanner detector initialized")
+    print("press [Ctrl+C] to quit")
+    sniffer = Thread(target=sniff, args=(data_queue,)) 
+    dissector = Thread(target=dissect, args=(data_queue, channel))
+    detector = Thread(target=detect, args=(channel,))
+     
+    sniffer.daemon = True
+    dissector.daemon = True
+    detector.daemon = True
+    
+    sniffer.start()
+    dissector.start()
+    detector.start()
+
+    try:
+        # Proof of concept showing we can fetch items from the queue
+        # Note: later we may as well replace this with a call to one of the other functions
+        num = 0
+        while True:
+            table = channel.get()
+            size = len(table)
+            if size != num:
+                more_or_less = "more" if size > num else "less"
+                print("we now have %d %s entries (total = %d)" % (size - num, more_or_less, size))
+                num = size
+            channel.put(table)
+        
+    except KeyboardInterrupt:
+        print()
+
+if __name__ == "__main__": 
+    main()
+

--- a/detector/psocket.py
+++ b/detector/psocket.py
@@ -1,0 +1,25 @@
+import socket
+import ctypes
+import fcntl
+
+# Found out how to do this here: https://stackoverflow.com/q/6067405/9990099
+class ifreq(ctypes.Structure):
+        _fields_ = [("ifr_ifrn", ctypes.c_char * 16), ("ifr_flags", ctypes.c_short)]
+
+IFF_PROMISC = 0x100
+SIOCGIFFLAGS = 0x8913 # G for Get
+SIOCSIFFLAGS = 0x8914 # S for Set
+
+# I suppose I'll leave this in global memory in case someone wants to change the interface
+ifr = ifreq()
+ifr.ifr_ifrn = b'eth0'
+
+def get_promiscuous_socket():
+    # Note: AF_PACKET does not work on Mac, but works on Linux
+    sock = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(0x0800))
+    fcntl.ioctl(sock.fileno(), SIOCGIFFLAGS, ifr)
+    ifr.ifr_flags |= IFF_PROMISC
+    fcntl.ioctl(sock.fileno(), SIOCSIFFLAGS, ifr)
+    return sock
+    
+

--- a/detector/sniffer.py
+++ b/detector/sniffer.py
@@ -1,0 +1,93 @@
+import socket
+from struct import unpack
+from datetime import datetime
+    
+# Note: AF_PACKET does not work on Mac, but works on Linux
+_packets = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(0x0800))
+
+# This function sniffs data and immediately puts it on a queue to be processed. It does this
+# so that it doesn't miss other incoming packets while processing the data or while waiting
+# to receive the table from another channel.
+# 
+# Note: not all packets will be received, but it allows us to capture x2 the number of
+# packets from before. It may also be beneficial to start two sniffers at once. When I tested
+# that, I got an extra 100 packets. Is the recvfrom method atomic as to prevent duplicates?
+def sniff(data_queue): 
+    
+    while True:
+        
+        # Does this only sniff packets incoming to the host? If so, that might mean
+        # storing the destination ip may not be necessary. At the moment, the destination
+        # ip in the key isn't ever referenced. I think it can be removed. TODO: Test this
+        ethernet_data, _ = _packets.recvfrom(65536)
+        data_queue.put(ethernet_data)
+
+def dissect(data_queue, channel):
+
+    while True:
+
+        ethernet_data = data_queue.get()
+        dst_mac, src_mac, protocol, ip_data = ethernet_dissect(ethernet_data)
+        
+        if protocol == EthernetProtocol.IPV4:
+            
+            ip_protocol, src_ip, dst_ip, transport_data = ipv4_dissect(ip_data)
+            
+            if ip_protocol == IPProtocol.ICMP:
+                icmp_type, icmp_code = icmp_dissect(transport_data)
+                # do nothing..
+            
+            if ip_protocol == IPProtocol.TCP:
+                src_port, dst_port = tcp_dissect(transport_data)
+                table = channel.get()
+                key = (src_ip, dst_ip, dst_port)
+                if key not in table:
+                    table[key] = datetime.now()
+                channel.put(table)
+                
+            elif ip_protocol == IPProtocol.UDP:
+                src_port, dst_port = udp_dissect(transport_data)
+                # do nothing..
+                
+                # After we implement a scanner detector for TCP,
+                # we may want to add UDP on top of that. We should
+                # distinguish TCP and UDP ports in the table we
+                # have, and we might need to incorporate logic
+                # taken from ICMP? (I don't think think this is
+                # the case)
+
+class EthernetProtocol():
+    IPV4 = 8
+
+class IPProtocol():
+    ICMP = 1
+    TCP = 6
+    UDP = 17
+
+def ethernet_dissect(ethernet_data):
+    dst_mac, src_mac, protocol = unpack('!6s 6s H', ethernet_data[:14])
+    return mac_format(dst_mac), mac_format(src_mac), socket.htons(protocol), ethernet_data[14:]
+
+def mac_format(mac):
+    mac = map('{:02x}'.format, mac)
+    return ':'.join(mac).upper()
+
+def ipv4_dissect(ip_data):
+    ip_protocol, source_ip, target_ip = unpack('!9x B 2x 4s 4s', ip_data[:20])
+    return ip_protocol, ipv4_format(source_ip), ipv4_format(target_ip), ip_data[20:]
+
+def ipv4_format(address):
+    return '.'.join(map(str, address))
+
+def icmp_dissect(transport_data):
+    icmp_type, code = unpack('!BB', transport_data[:2])
+    return icmp_type, code
+
+def tcp_dissect(transport_data):
+    source_port, dst_port = unpack('!HH', transport_data[:4])
+    return source_port, dst_port
+
+def udp_dissect(transport_data):
+    source_port, dst_port = unpack('!HH', transport_data[:4])
+    return source_port, dst_port
+

--- a/detector/sniffer.py
+++ b/detector/sniffer.py
@@ -7,11 +7,13 @@ _packets = psocket.get_promiscuous_socket()
 
 # This function sniffs data and immediately puts it on a queue to be processed. It does this
 # so that it doesn't miss other incoming packets while processing the data or while waiting
-# to receive the table from another channel.
+# to receive the table from another channel. Note that in some circumstances packets will still
+# not make it though. This could potentially happen if the OS doesn't assign this program enough
+# thread time due to other bloated programs or general low performance. If a significant number
+# of packets aren't making it, consider 1) whether something is taking too long in a critical
+# section and 2) whether or not a second sniffer thread would work. In an early test case, this
+# scaled well.
 # 
-# Note: not all packets will be received, but it allows us to capture x2 the number of
-# packets from before. It may also be beneficial to start two sniffers at once. When I tested
-# that, I got an extra 100 packets. Is the recvfrom method atomic as to prevent duplicates?
 def sniff(data_queue): 
     
     while True:


### PR DESCRIPTION
* Modularized functions into their own files
* Using default python dictionary instead of computing index manually
* Using channels among threads to pass data in a threadsafe way
* Removed timer thread (put into detector thread function)
* Added dissector thread so that the sniffer won't drop packets while dissecting
* Tested running of program across a span of 5 minutes for a -T4 speed on nmap
* Made [Ctrl+C] exit the program smoothly (as opposed to needing to Ctrl+C for each thread)

**EDIT: Fixed this, see below**
At this point, the dst_ip is not used. It is not clear if it could be used.
This is something to test across at least 3 machines on a network.

**EDIT: Tested this, see below**
I think different speeds should be tested, and it would be interesting to
even test multiple port scanners at once. At the moment, the port scanner
still needs to be updated to scan at different rates, since in the end it
seems we should be using that over nmap.

Note: I also removed comments temporarily. This is why I haven't deleted
the original file yet. They can be added back, but I didn't want to since
I would have felt compelled to make similar comments for new functions.
TL;DR The result of this is a combination of OCD and Laziness